### PR TITLE
Prevent multi feature selection using shift + click

### DIFF
--- a/src/app/main/map/map.service.js
+++ b/src/app/main/map/map.service.js
@@ -270,6 +270,7 @@
         condition: function(event) {
           return ol.events.condition.singleClick(event) && !isAnyDrawingToolActive();
         },
+        toggleCondition: ol.events.condition.never,
         layers: vectorLayers
       });
 
@@ -279,11 +280,6 @@
 
       mapInteractions.featureSelect.on("select", function(e) {
         $rootScope.$broadcast("toggle-feature-panel", e);
-
-        if (e.selected.length) {
-          clearSelectedFeatures();
-          mapInteractions.featureSelect.getFeatures().push(e.selected[0]);
-        }
       });
 
       mapInteractions.featureModify.on("modifyend", function() {

--- a/src/app/main/map/map.service.js
+++ b/src/app/main/map/map.service.js
@@ -279,6 +279,11 @@
 
       mapInteractions.featureSelect.on("select", function(e) {
         $rootScope.$broadcast("toggle-feature-panel", e);
+
+        if (e.selected.length) {
+          clearSelectedFeatures();
+          mapInteractions.featureSelect.getFeatures().push(e.selected[0]);
+        }
       });
 
       mapInteractions.featureModify.on("modifyend", function() {


### PR DESCRIPTION
Since I could find no way to this natively using Openlayers, I implemented a solution where I remove all selected features from the stack and add the one that was last selected